### PR TITLE
Adding OpenSearch example

### DIFF
--- a/opensearch-example/pom.xml
+++ b/opensearch-example/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>opensearch-example</artifactId>
+    <version>0.23.0</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <opensearch-java.version>2.6.0</opensearch-java.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-java</artifactId>
+            <version>${opensearch-java.version}</version>
+        </dependency>    
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-opensearch</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/opensearch-example/src/main/java/OpenSearchEmbeddingStoreExample.java
+++ b/opensearch-example/src/main/java/OpenSearchEmbeddingStoreExample.java
@@ -1,0 +1,45 @@
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.AllMiniLmL6V2EmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.opensearch.OpenSearchEmbeddingStore;
+
+import java.util.List;
+
+public class OpenSearchEmbeddingStoreExample {
+
+    /**
+     * To run this example, ensure you have OpenSearch running locally. If not, then:
+     * - Execute "docker pull opensearchproject/opensearch:latest"
+     * - Execute "docker run -d -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "DISABLE_INSTALL_DEMO_CONFIG=true" -e "DISABLE_SECURITY_PLUGIN=true" opensearchproject/opensearch:latest"
+     * - Wait until OpenSearch  is ready to serve (may take a few minutes)
+     */
+
+    public static void main(String[] args) throws InterruptedException {
+
+        EmbeddingStore<TextSegment> embeddingStore = OpenSearchEmbeddingStore.builder()
+                .serverUrl("http://localhost:9200")
+                .build();
+
+        EmbeddingModel embeddingModel = new AllMiniLmL6V2EmbeddingModel();
+
+        TextSegment segment1 = TextSegment.from("I like football.");
+        Embedding embedding1 = embeddingModel.embed(segment1).content();
+        embeddingStore.add(embedding1, segment1);
+
+        TextSegment segment2 = TextSegment.from("The weather is good today.");
+        Embedding embedding2 = embeddingModel.embed(segment2).content();
+        embeddingStore.add(embedding2, segment2);
+
+        Thread.sleep(1000); // to be sure that embeddings were persisted
+
+        Embedding queryEmbedding = embeddingModel.embed("What is your favourite sport?").content();
+        List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(queryEmbedding, 1);
+        EmbeddingMatch<TextSegment> embeddingMatch = relevant.get(0);
+
+        System.out.println(embeddingMatch.score()); // 0.8144289
+        System.out.println(embeddingMatch.embedded().text()); // I like football.
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <module>spring-boot-example</module>
         <module>vespa-example</module>
         <module>weaviate-example</module>
+        <module>opensearch-example</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This PR adds support for an example using OpenSearch. Support for OpenSearch was added to the project via [this PR](https://github.com/langchain4j/langchain4j/pull/208).