### PR TITLE
Added testcontainer to Redis example

### DIFF
--- a/redis-example/pom.xml
+++ b/redis-example/pom.xml
@@ -28,6 +28,24 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.redis.testcontainers</groupId>
+            <artifactId>testcontainers-redis</artifactId>
+            <version>1.6.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.19.1</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/redis-example/src/main/java/RedisEmbeddingStoreExample.java
+++ b/redis-example/src/main/java/RedisEmbeddingStoreExample.java
@@ -8,20 +8,18 @@ import dev.langchain4j.store.embedding.redis.RedisEmbeddingStore;
 
 import java.util.List;
 
-public class RedisEmbeddingStoreExample {
+import com.redis.testcontainers.RedisStackContainer;
 
-    /**
-     * To run this example, ensure you have Redis running locally. If not, then:
-     * - Execute "docker pull redis/redis-stack:latest"
-     * - Execute "docker run -d -p 6379:6379 -p 8001:8001 redis/redis-stack:latest"
-     * - Wait until Redis is ready to serve (may take a few minutes)
-     */
+public class RedisEmbeddingStoreExample {
 
     public static void main(String[] args) {
 
+        RedisStackContainer redis = new RedisStackContainer(RedisStackContainer.DEFAULT_IMAGE_NAME.withTag(RedisStackContainer.DEFAULT_TAG));
+        redis.start();
+
         EmbeddingStore<TextSegment> embeddingStore = RedisEmbeddingStore.builder()
-                .host("localhost")
-                .port(6379)
+                .host(redis.getHost())
+                .port(redis.getFirstMappedPort())
                 .dimension(384)
                 .build();
 
@@ -41,5 +39,7 @@ public class RedisEmbeddingStoreExample {
 
         System.out.println(embeddingMatch.score()); // 0.8144288659095
         System.out.println(embeddingMatch.embedded().text()); // I like football.
+        
+        redis.stop();
     }
 }


### PR DESCRIPTION
Added a testcontainer instance so that example does not need a separately managed Redis