### PR TITLE
docs: Qdrant usage example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>opensearch-example</module>
         <module>other-examples</module>
         <module>pinecone-example</module>
+        <module>qdrant-example</module>
         <module>redis-example</module>
         <module>spring-boot-example</module>
         <module>vertex-ai-gemini-examples</module>

--- a/qdrant-example/pom.xml
+++ b/qdrant-example/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>qdrant-example</artifactId>
+    <version>0.26.1</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-qdrant</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/qdrant-example/src/main/java/QdrantEmbeddingStoreExample.java
+++ b/qdrant-example/src/main/java/QdrantEmbeddingStoreExample.java
@@ -1,0 +1,41 @@
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.AllMiniLmL6V2EmbeddingModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import java.util.List;
+
+public class QdrantEmbeddingStoreExample {
+
+  public static void main(String[] args) {
+
+    EmbeddingStore<TextSegment> embeddingStore =
+        QdrantEmbeddingStore.builder()
+            // Ensure the collection is configured with the appropriate dimensions
+            // of the embedding model.
+            .collectionName("{collection_name}")
+            .host("localhost")
+            // GRPC port of the Qdrant server
+            .port(6334)
+            .build();
+
+    EmbeddingModel embeddingModel = new AllMiniLmL6V2EmbeddingModel();
+
+    TextSegment segment1 = TextSegment.from("I've been to France twice.");
+    Embedding embedding1 = embeddingModel.embed(segment1).content();
+    embeddingStore.add(embedding1, segment1);
+
+    TextSegment segment2 = TextSegment.from("New Delhi is the capital of India.");
+    Embedding embedding2 = embeddingModel.embed(segment2).content();
+    embeddingStore.add(embedding2, segment2);
+
+    Embedding queryEmbedding = embeddingModel.embed("Did you ever travel abroad?").content();
+    List<EmbeddingMatch<TextSegment>> relevant = embeddingStore.findRelevant(queryEmbedding, 1);
+    EmbeddingMatch<TextSegment> embeddingMatch = relevant.get(0);
+
+    System.out.println(embeddingMatch.score());
+    System.out.println(embeddingMatch.embedded().text());
+  }
+}


### PR DESCRIPTION
Adds usage example for the `langchain4j-qdrant` module.