### PR TITLE
Fix: rename path to text resource

### DIFF
--- a/tutorials/src/main/java/_02_OpenAiImageModelExamples.java
+++ b/tutorials/src/main/java/_02_OpenAiImageModelExamples.java
@@ -70,7 +70,7 @@ public class _02_OpenAiImageModelExamples {
                     Paths.get(
                             Objects
                                     .requireNonNull(
-                                            _02_OpenAiImageModelExamples.class.getResource("example-files/story-about" +
+                                            _02_OpenAiImageModelExamples.class.getResource("story-about" +
                                                     "-happy-carrot.txt")
                                     )
                                     .toURI()


### PR DESCRIPTION
Rename path to the text resource to correspond its current location. Looks like there were a directory with name `example-files` but now it's gone.