### PR TITLE
Add instructions for running tutorials from a jar and as native images

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,6 +1,6 @@
-## Packaging as a fat jar
+## Running the examples from the command line
 
-You can just execute each tutorial from your IDE. In case you want to produce a fat jar with all the dependencies, do the following.
+You can just execute each tutorial from your IDE. In case you want to produce a jar with all the dependencies, do the following.
 
 1. Package the project with the `complete` profile:
 
@@ -10,5 +10,20 @@ mvn -Pcomplete package
 2. Run individual apps, such as `_00_HelloWorld`, with the following command:
 
 ```shell
-java -cp ./target/tutorials-0.28.0-jar-with-dependencies.jar _00_HelloWorld
+java -cp ./target/tutorials-0.28.0-jar-with-dependencies.jar _00_HelloWorld "what is Java?"
+```
+
+## Running the examples as GraalVM native images
+
+In case you want to produce a native executable version of your app, same command as above works with `native-image`:
+
+```shell
+native-image -cp ./target/tutorials-0.28.0-jar-with-dependencies.jar _00_HelloWorld -o native-helloworld
+
+```
+
+You can then run it as a native executable, and pass your prompt like before:
+
+```shell
+./native-helloworld "what is Java?"
 ```

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,0 +1,14 @@
+## Packaging as a fat jar
+
+You can just execute each tutorial from your IDE. In case you want to produce a fat jar with all the dependencies, do the following.
+
+1. Package the project with the `complete` profile:
+
+```shell
+mvn -Pcomplete package
+```
+2. Run individual apps, such as `_00_HelloWorld`, with the following command:
+
+```shell
+java -cp ./target/tutorials-0.28.0-jar-with-dependencies.jar _00_HelloWorld
+```

--- a/tutorials/pom.xml
+++ b/tutorials/pom.xml
@@ -73,8 +73,6 @@
                     </descriptorRefs>
                     <archive>
                         <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>${main.class}</mainClass>
                         </manifest>
                     </archive>
                 </configuration>

--- a/tutorials/pom.xml
+++ b/tutorials/pom.xml
@@ -56,7 +56,41 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
     </dependencies>
+
+<profiles>
+    <profile>
+    <id>complete</id>
+        <build>   
+            <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>${main.class}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            </plugins>
+        </build>
+    </profile>
+</profiles>
 
 </project>


### PR DESCRIPTION
Hi, 

This PR adds instructions and a pom.xml change for executing tutorials from the command line (via a separate Maven profile, so hopefully it works). i find it useful overall, but also it helps package apps in a way that can be sent to Native Image. I will follow up with more Native-Image specific examples. 

Let me know what you think :)