### PR TITLE
Adding examples for BedrockChatModel and BedrockStreamingChatModel

### DIFF
--- a/bedrock-examples/pom.xml
+++ b/bedrock-examples/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>bedrock-examples</artifactId>
+    <version>0.31.0</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-bedrock</artifactId>
+            <version>0.31.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>0.31.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>tinylog-impl</artifactId>
+            <version>2.6.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.tinylog</groupId>
+            <artifactId>slf4j-tinylog</artifactId>
+            <version>2.6.2</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/bedrock-examples/src/main/java/BedrockChatModelExample.java
+++ b/bedrock-examples/src/main/java/BedrockChatModelExample.java
@@ -1,0 +1,27 @@
+import dev.langchain4j.model.bedrock.BedrockAnthropicMessageChatModel;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import software.amazon.awssdk.regions.Region;
+
+public class BedrockChatModelExample {
+
+    public static void main(String[] args) {
+
+        // For authentication, set the following environment variables:
+        // AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+        // More info on creating the API keys:
+        // https://docs.aws.amazon.com/bedrock/latest/userguide/api-setup.html
+        ChatLanguageModel model = BedrockAnthropicMessageChatModel
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaude3SonnetV1.getValue())
+                .maxRetries(1)
+                // Other parameters can be set as well
+                .build();
+
+        String joke = model.generate("Tell me a joke about Java");
+
+        System.out.println(joke);
+    }
+}

--- a/bedrock-examples/src/main/java/BedrockStreamingChatModelExample.java
+++ b/bedrock-examples/src/main/java/BedrockStreamingChatModelExample.java
@@ -1,0 +1,45 @@
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.StreamingResponseHandler;
+import dev.langchain4j.model.bedrock.BedrockAnthropicMessageChatModel;
+import dev.langchain4j.model.bedrock.BedrockAnthropicStreamingChatModel;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+import software.amazon.awssdk.regions.Region;
+
+public class BedrockStreamingChatModelExample {
+
+    public static void main(String[] args) {
+
+        // For authentication, set the following environment variables:
+        // AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+        // More info on creating the API keys:
+        // https://docs.aws.amazon.com/bedrock/latest/userguide/api-setup.html
+        StreamingChatLanguageModel model = BedrockAnthropicStreamingChatModel
+                .builder()
+                .temperature(0.50f)
+                .maxTokens(300)
+                .region(Region.US_EAST_1)
+                .model(BedrockAnthropicMessageChatModel.Types.AnthropicClaudeV2.getValue())
+                .maxRetries(1)
+                // Other parameters can be set as well
+                .build();
+
+        model.generate("Write a poem about Java", new StreamingResponseHandler<AiMessage>() {
+
+            @Override
+            public void onNext(String token) {
+                System.out.println("onNext(): " + token);
+            }
+
+            @Override
+            public void onComplete(Response<AiMessage> response) {
+                System.out.println("onComplete(): " + response);
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                error.printStackTrace();
+            }
+        });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <modules>
         <module>anthropic-examples</module>
         <module>azure-open-ai-examples</module>
+        <module>bedrock-examples</module>
         <module>chroma-example</module>
         <module>customer-support-agent-example</module>
         <module>tutorials</module>


### PR DESCRIPTION
Added 2 example classes:
- `BedrockChatModelExample`
- `BedrockStreamingChatModelExample`
in new module `bedrock-examples`

When running the examples on my machine, a lot of debugging info is printed to console, interfering with the observability of the response streaming. I'm unsure if this can be switched off and where, it may be something I encounter locally only.