### PR TITLE
Update Elasticsearch example

### DIFF
--- a/elasticsearch-example/pom.xml
+++ b/elasticsearch-example/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-elasticsearch</artifactId>
-            <version>0.34.0-SNAPSHOT</version>
+            <version>0.34.0</version>
         </dependency>
 
         <dependency>

--- a/elasticsearch-example/pom.xml
+++ b/elasticsearch-example/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-elasticsearch</artifactId>
-            <version>0.33.0</version>
+            <version>0.34.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.19.6</version>
+            <version>1.20.1</version>
         </dependency>
 
     </dependencies>

--- a/elasticsearch-example/src/main/java/ElasticsearchEmbeddingStoreWithScriptExample.java
+++ b/elasticsearch-example/src/main/java/ElasticsearchEmbeddingStoreWithScriptExample.java
@@ -1,11 +1,12 @@
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchConfigurationScript;
 import dev.langchain4j.store.embedding.elasticsearch.ElasticsearchEmbeddingStore;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -18,7 +19,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 import java.io.IOException;
 
-public class ElasticsearchEmbeddingStoreExample {
+public class ElasticsearchEmbeddingStoreWithScriptExample {
 
     public static void main(String[] args) throws IOException {
 
@@ -41,6 +42,7 @@ public class ElasticsearchEmbeddingStoreExample {
 
             EmbeddingStore<TextSegment> embeddingStore = ElasticsearchEmbeddingStore.builder()
                     .restClient(client)
+                    .configuration(ElasticsearchConfigurationScript.builder().build())
                     .build();
 
             EmbeddingModel embeddingModel = new AllMiniLmL6V2EmbeddingModel();
@@ -63,7 +65,7 @@ public class ElasticsearchEmbeddingStoreExample {
                             .build());
             EmbeddingMatch<TextSegment> embeddingMatch = relevant.matches().get(0);
 
-            System.out.println(embeddingMatch.score()); // 0.8138435
+            System.out.println(embeddingMatch.score()); // 0.81442887
             System.out.println(embeddingMatch.embedded().text()); // I like football.
 
             client.close();


### PR DESCRIPTION
* We don't disable security so we use login/password and self signed certificates which is even closer to production ready code
* We use the new 0.34 Elasticsearch embedding store
  - which is now using a rest client
  - and is using the approximate kNN implementation
* We add another example `ElasticsearchEmbeddingStoreWithScriptExample` using the `ElasticsearchConfigurationScript` configuration.
* We call the refresh API instead of waiting for 1s
* We used Elasticsearch 8.15.0 for our tests