### PR TITLE
Some projects do not run on Java 8

### DIFF
--- a/other-examples/pom.xml
+++ b/other-examples/pom.xml
@@ -9,8 +9,8 @@
     <version>0.34.0</version>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/rag-examples/pom.xml
+++ b/rag-examples/pom.xml
@@ -9,8 +9,8 @@
     <version>0.34.0</version>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
The following declare a Java version of 8, but uses Logback `1.5.x`, which [requires Java 11 since `1.4.x`](https://logback.qos.ch/download.html):
- `rag-examples` 
- `other-examples`

When run on JDK8, the following is logged:
```
Exception in thread "main" java.lang.UnsupportedClassVersionError: ch/qos/logback/classic/spi/LogbackServiceProvider has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:370)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
	at org.slf4j.LoggerFactory.safelyInstantiate(LoggerFactory.java:134)
	at org.slf4j.LoggerFactory.findServiceProviders(LoggerFactory.java:115)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:178)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:170)
	at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:455)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:441)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:390)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:416)
	at dev.langchain4j.data.document.loader.FileSystemDocumentLoader.<clinit>(FileSystemDocumentLoader.java:31)
	at _1_easy.Easy_RAG_Example.main(Easy_RAG_Example.java:33)
```

Updated Java code level to 11.