### PR TITLE
Update jakartaee-microprofile-example to use MicroProfile 7

### DIFF
--- a/jakartaee-microprofile-example/README.md
+++ b/jakartaee-microprofile-example/README.md
@@ -3,7 +3,7 @@ This example demonstrates LangChain4J in a Jakarta EE / MicroProfile application
 
 ## Prerequisites:
 
-- [Java 17](https://developer.ibm.com/languages/java/semeru-runtimes/downloads)
+- [Java 21](https://developer.ibm.com/languages/java/semeru-runtimes/downloads)
 - Hugging Face API Key
   - Sign up and log in to https://huggingface.co.
   - Go to [Access Tokens](https://huggingface.co/settings/tokens). 
@@ -21,7 +21,7 @@ cd langchain4j-examples/jakartaee-microprofile-example
 Set the following environment variables:
 
 ```
-export JAVA_HOME=<your Java 17 home path>
+export JAVA_HOME=<your Java 21 home path>
 export HUGGING_FACE_API_KEY=<your Hugging Face read token>
 ```
 
@@ -44,7 +44,7 @@ Use the Maven wrapper to start the application by using the [Liberty dev mode](h
     Which are the most used models?
     ```
   - ```
-    any documentation?
+    show me the documentation
     ```
 
 

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -10,8 +10,8 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.1</version>
+            <version>7.0</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -42,24 +42,24 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.16</version>
         </dependency>
         <!-- For tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.10.Final</version>
+            <version>6.2.11.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -94,7 +94,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.11.1</version>
+                    <version>3.11.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -106,7 +106,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.5.2</version>
             </plugin>
         </plugins>
     </build>

--- a/jakartaee-microprofile-example/src/main/java/dev/langchain4j/example/chat/ChatAgent.java
+++ b/jakartaee-microprofile-example/src/main/java/dev/langchain4j/example/chat/ChatAgent.java
@@ -65,7 +65,9 @@ public class ChatAgent {
     }
 
     public String chat(String sessionId, String message) {
-        return getAssistant().chat(sessionId, message).trim();
+        String reply = getAssistant().chat(sessionId, message).trim();
+        int i = reply.lastIndexOf(message);
+        return i > 0 ? reply.substring(i) : reply;
     }
 
 }

--- a/jakartaee-microprofile-example/src/main/liberty/config/server.xml
+++ b/jakartaee-microprofile-example/src/main/liberty/config/server.xml
@@ -2,13 +2,15 @@
 <server description="chat server">
 
     <featureManager>
-        <feature>cdi-4.0</feature>
-        <feature>jsonb-3.0</feature>
-        <feature>mpConfig-3.1</feature>
-        <feature>mpMetrics-5.1</feature>
-        <feature>mpOpenAPI-3.1</feature>
-        <feature>restfulWS-3.1</feature>
-        <feature>websocket-2.1</feature>
+        <platform>jakartaee-10.0</platform>
+        <platform>microprofile-7.0</platform>
+        <feature>cdi</feature>
+        <feature>jsonb</feature>
+        <feature>mpConfig</feature>
+        <feature>mpMetrics</feature>
+        <feature>mpOpenAPI</feature>
+        <feature>restfulWS</feature>
+        <feature>websocket</feature>
     </featureManager>
 
     <httpEndpoint host="*" httpPort="9080" httpsPort="9443" id="defaultHttpEndpoint"/>

--- a/jakartaee-microprofile-example/src/main/resources/META-INF/microprofile-config.properties
+++ b/jakartaee-microprofile-example/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,6 @@
 hugging.face.api.key=set it by env variable
-chat.model.id=NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO
+#chat.model.id=meta-llama/Llama-3.2-1B-Instruct
+chat.model.id=mistralai/Mistral-Nemo-Instruct-2407
 chat.model.timeout=120
 chat.model.max.token=200
 chat.model.temperature=1.0

--- a/jakartaee-microprofile-example/src/test/java/it/dev/langchan4j/example/ChatServiceIT.java
+++ b/jakartaee-microprofile-example/src/test/java/it/dev/langchan4j/example/ChatServiceIT.java
@@ -21,7 +21,7 @@ public class ChatServiceIT {
         countDown = new CountDownLatch(1);
         URI uri = new URI("ws://localhost:9080/chat");
         ChatClient client = new ChatClient(uri);
-        client.sendMessage("When was langchain4j launched?");
+        client.sendMessage("When was the LangChain4j launched?");
         countDown.await(120, TimeUnit.SECONDS);
         client.close();
     }


### PR DESCRIPTION
update the jakartaee-microprofile-example
- use MicroProfile 7
- replace the default chat model to `mistralai/Mistral-Nemo-Instruct-2407`
- update the Maven project to use Java 21 and latest dependencies