### PR TITLE
Fix the jakartaee-microprofile-example because language model is too big

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: maven
-  directory: "/jakartaee-microprofile-example"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/jakartaee-microprofile-example"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/jakartaee-microprofile-example/README.md
+++ b/jakartaee-microprofile-example/README.md
@@ -55,11 +55,12 @@ Navigate to the the [OpenAPI UI](http://localhost:9080/openapi/ui) URL for the f
 - [HuggingFaceLanguageModel](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-hugging-face/src/main/java/dev/langchain4j/model/huggingface/HuggingFaceLanguageModel.java)
   - Expand the GET `/api/model/language` API.
     1. Click the **Try it out** button.
-    2. Type `When was langchain4j launched?`, or any question, in the question field.
+    2. Type `When was Hugging Face launched?`, or any question, in the question field.
     3. Click the **Execute** button.
   - Alternatively, run the following `curl` command from a command-line session:
     - ```
-      curl 'http://localhost:9080/api/model/language?question=When%20was%20langchain4j%20launched%3F'
+      curl 'http://localhost:9080/api/model/language?question=When%20was%20Hugging%20Face%20launched%3F'
+
       ```
 - [HuggingFaceChatModel](https://github.com/langchain4j/langchain4j/blob/main/langchain4j-hugging-face/src/main/java/dev/langchain4j/model/huggingface/HuggingFaceChatModel.java)
   - expand the GET `/api/model/chat` API
@@ -68,7 +69,7 @@ Navigate to the the [OpenAPI UI](http://localhost:9080/openapi/ui) URL for the f
     3. Click the **Execute** button.
   - Alternatively, run the following `curl` command from a command-line session:
     - ```
-      curl 'http://localhost:9080/api/model/chat?userMessage=Which%20are%20the%20most%20used%20Large%20Language%20models%3F' | jq
+      curl 'http://localhost:9080/api/model/chat?userMessage=Which%20are%20the%20most%20used%20Large%20Language%20Models%3F' | jq
       ```
 - [InProcessEmbeddingModel](https://github.com/langchain4j/langchain4j-embeddings)
   - expand the GET `/api/model/similarity` API

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -106,7 +106,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.3</version>
             </plugin>
         </plugins>
     </build>

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17</version>
         </dependency>
         <!-- For tests -->
         <dependency>

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.11.Final</version>
+            <version>6.2.12.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-client</artifactId>
-            <version>11.0.24</version>
+            <version>11.0.25</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.11.Final</version>
+            <version>6.2.12.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jakartaee-microprofile-example/pom.xml
+++ b/jakartaee-microprofile-example/pom.xml
@@ -94,7 +94,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.11.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/jakartaee-microprofile-example/src/main/java/dev/langchain4j/example/rest/ModelResource.java
+++ b/jakartaee-microprofile-example/src/main/java/dev/langchain4j/example/rest/ModelResource.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 
 import static dev.langchain4j.data.segment.TextSegment.textSegment;
 import static dev.langchain4j.model.huggingface.HuggingFaceModelName.SENTENCE_TRANSFORMERS_ALL_MINI_LM_L6_V2;
-import static dev.langchain4j.model.huggingface.HuggingFaceModelName.TII_UAE_FALCON_7B_INSTRUCT;
 import static dev.langchain4j.store.embedding.CosineSimilarity.between;
 import static dev.langchain4j.store.embedding.RelevanceScore.fromCosineSimilarity;
 import static java.time.Duration.ofSeconds;
@@ -36,6 +35,10 @@ public class ModelResource {
     @ConfigProperty(name = "hugging.face.api.key")
     private String HUGGING_FACE_API_KEY;
 
+    @Inject
+    @ConfigProperty(name = "language.model.id")
+    private String LANGUAGE_MODEL_ID;
+
     private HuggingFaceLanguageModel languageModel = null;
     private HuggingFaceEmbeddingModel embeddingModel = null;
 
@@ -43,7 +46,7 @@ public class ModelResource {
         if (languageModel == null) {
             languageModel = HuggingFaceLanguageModel.builder()
                     .accessToken(HUGGING_FACE_API_KEY)
-                    .modelId(TII_UAE_FALCON_7B_INSTRUCT)
+                    .modelId(LANGUAGE_MODEL_ID)
                     .timeout(ofSeconds(120))
                     .temperature(1.0)
                     .maxNewTokens(30)
@@ -99,7 +102,7 @@ public class ModelResource {
 
         HuggingFaceChatModel model = HuggingFaceChatModel.builder()
                 .accessToken(HUGGING_FACE_API_KEY)
-                .modelId(TII_UAE_FALCON_7B_INSTRUCT)
+                .modelId(LANGUAGE_MODEL_ID)
                 .timeout(ofSeconds(120))
                 .temperature(1.0)
                 .maxNewTokens(200)

--- a/jakartaee-microprofile-example/src/main/resources/META-INF/microprofile-config.properties
+++ b/jakartaee-microprofile-example/src/main/resources/META-INF/microprofile-config.properties
@@ -5,3 +5,4 @@ chat.model.timeout=120
 chat.model.max.token=200
 chat.model.temperature=1.0
 chat.memory.max.messages=20
+language.model.id=microsoft/Phi-3-mini-4k-instruct

--- a/jakartaee-microprofile-example/src/test/java/it/dev/langchan4j/example/ModelResourceIT.java
+++ b/jakartaee-microprofile-example/src/test/java/it/dev/langchan4j/example/ModelResourceIT.java
@@ -29,10 +29,10 @@ public class ModelResourceIT {
     
     @Test
     public void testLanguageMode() {
-        String url = baseUrl + "language?question=When was langchain4j launched?";
+        String url = baseUrl + "language?question=When was Hugging Face launched?";
         Response response = client.target(url).request().get();
         String answer = response.readEntity(String.class);
-        assertTrue(answer.contains("2017"), "actual: " + answer);
+        assertTrue(answer.contains("2018"), "actual: " + answer);
     }
 
     @Test


### PR DESCRIPTION
Because `tiiuae/falcon-7b-instruct` model is greater than 10G, the Hugging Face free account cannot load it. This PR fixes the jakartaee-microprofile-example with the following:
- update the `ModelResource.java` to use the `microsoft/Phi-3-mini-4k-instruct` model
- update the test in the `ModelResourceIT.java`
- update the Maven dependencies to latest in the `pom.xml`
- update the `README.md`