### PR TITLE
Fix: StreamingChatResponseHandler Reuse Causes Async Response Loss in…

### DIFF
--- a/tutorials/src/main/java/_05_Memory.java
+++ b/tutorials/src/main/java/_05_Memory.java
@@ -28,7 +28,7 @@ public class _05_Memory {
         SystemMessage systemMessage = SystemMessage.from(
                 "You are a senior developer explaining to another senior developer, "
                         + "the project you are working on is an e-commerce platform with Java back-end, " +
-                        "Oracle database,and Spring Data JPA");
+                        "Oracle database, and Spring Data JPA");
         chatMemory.add(systemMessage);
 
 
@@ -39,6 +39,24 @@ public class _05_Memory {
 
         System.out.println("[User]: " + userMessage1.singleText());
         System.out.print("[LLM]: ");
+
+        AiMessage aiMessage1 = streamChat(model, chatMemory);
+        chatMemory.add(aiMessage1);
+
+        UserMessage userMessage2 = userMessage(
+                "Give a concrete example implementation of the first point? " +
+                        "Be short, 10 lines of code maximum.");
+        chatMemory.add(userMessage2);
+
+        System.out.println("\n\n[User]: " + userMessage2.singleText());
+        System.out.print("[LLM]: ");
+
+        AiMessage aiMessage2 = streamChat(model, chatMemory);
+        chatMemory.add(aiMessage2);
+    }
+
+    private static AiMessage streamChat(OpenAiStreamingChatModel model, ChatMemory chatMemory)
+            throws ExecutionException, InterruptedException {
 
         CompletableFuture<AiMessage> futureAiMessage = new CompletableFuture<>();
 
@@ -60,16 +78,6 @@ public class _05_Memory {
         };
 
         model.chat(chatMemory.messages(), handler);
-        chatMemory.add(futureAiMessage.get());
-
-        UserMessage userMessage2 = userMessage(
-                "Give a concrete example implementation of the first point? " +
-                        "Be short, 10 lines of code maximum.");
-        chatMemory.add(userMessage2);
-
-        System.out.println("\n\n[User]: " + userMessage2.singleText());
-        System.out.print("[LLM]: ");
-
-        model.chat(chatMemory.messages(), handler);
+        return futureAiMessage.get();
     }
 }


### PR DESCRIPTION
… Multiple Chat Calls

The current implementation in the tutorial code reuses a single StreamingChatResponseHandler with the same CompletableFuture<AiMessage> across multiple chat calls. While the handler itself is stateless, the CompletableFuture it uses becomes completed after the first call. This causes subsequent chat calls to not properly capture responses, as the future is already in a completed state and cannot accept new results.

The tutorial code should be updated to create a new CompletableFuture<AiMessage> and corresponding StreamingChatResponseHandler for each chat call. This ensures that each request has its own dedicated future to capture the response properly. A clear example showing the correct pattern for handling multiple streaming chat requests would be beneficial for users learning from the examples.

Creating a reusable handler that internally manages new futures for each call
Adding a reset() method to the existing handler implementation to clear the completed state
Adding clear documentation warning about this limitation when reusing handlers

This issue specifically affects asynchronous processing scenarios where multiple streaming chat requests are made sequentially. The current implementation might give the impression that handlers are fully reusable, which could lead to subtle bugs in production applications built following these examples.