### PR TITLE
Add Readme and Fix mcp/git server URL

### DIFF
--- a/mcp-github-example/Readme.md
+++ b/mcp-github-example/Readme.md
@@ -45,7 +45,8 @@ Run the `McpGithubToolsExample` class. This will:
 - Use the LLM to summarise the last 3 commits of the [LangChain4j GitHub repository](https://github.com/langchain4j/langchain4j).
 
 You can run the example from your IDE or with Maven:
-`mvn exec:java -Dexec.mainClass=dev.langchain4j.example.mcp.github.McpGithubToolsExample`
+
+```mvn exec:java -Dexec.mainClass=dev.langchain4j.example.mcp.github.McpGithubToolsExample```
 
 ## Notes
 

--- a/mcp-github-example/Readme.md
+++ b/mcp-github-example/Readme.md
@@ -1,0 +1,50 @@
+# MCP GitHub Tools Example
+
+This project demonstrates how to use the [LangChain4j](https://github.com/langchain4j/langchain4j) framework with the GitHub MCP (Model Context Protocol) server to summarize the latest commits of a public GitHub repository using an LLM (Large Language Model).
+
+## Features
+
+- Connects to the GitHub MCP server via Docker and stdin/stdout.
+- Uses OpenAI's GPT-4o-mini model to process and summarize commit data.
+- No authentication required for public repositories.
+
+## Prerequisites
+
+- Java (JDK 17+ recommended)
+- Maven
+- Docker (installed and running)
+- OpenAI API key (set as the `OPENAI_API_KEY` environment variable)
+
+## Setup
+
+1. **Build the GitHub MCP Docker image:**
+
+   Follow the instructions at [modelcontextprotocol/servers/src/github](https://github.com/modelcontextprotocol/servers/tree/main/src/git) to build the `mcp/git` Docker image.
+```sh
+   git clone https://github.com/modelcontextprotocol/servers.git
+   cd servers/src/github
+   docker build -t mcp/git .
+   docker run -i mcp/git
+   ```
+2. **Set your OpenAI API key:**
+```sh
+   export OPENAI_API_KEY=your_openai_api_key
+   ```
+3. **Clone this repository and build the project:** 
+git clone <this-repo-url> cd <this-repo> mvn clean package
+
+4. ## Running the Example
+
+Run the `McpGithubToolsExample` class. This will:
+
+- Start the GitHub MCP server in a Docker container.
+- Use the LLM to summarize the last 3 commits of the [LangChain4j GitHub repository](https://github.com/langchain4j/langchain4j).
+
+You can run the example from your IDE or with Maven:
+`mvn exec:java -Dexec.mainClass=dev.langchain4j.example.mcp.github.McpGithubToolsExample`
+
+## Notes
+
+- The MCP server is started as a subprocess using Docker. Make sure Docker is available at `/usr/local/bin/docker` or adjust the path in the code if needed.
+- The example does not require a GitHub personal access token for public repositories, but you can provide one via the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable if needed.
+

--- a/mcp-github-example/Readme.md
+++ b/mcp-github-example/Readme.md
@@ -1,11 +1,11 @@
 # MCP GitHub Tools Example
 
-This project demonstrates how to use the [LangChain4j](https://github.com/langchain4j/langchain4j) framework with the GitHub MCP (Model Context Protocol) server to summarize the latest commits of a public GitHub repository using an LLM (Large Language Model).
+This project demonstrates how to use the [LangChain4j](https://github.com/langchain4j/langchain4j) framework with the GitHub MCP (Model Context Protocol) server to summarise the latest commits of a public GitHub repository using an LLM (Large Language Model).
 
 ## Features
 
 - Connects to the GitHub MCP server via Docker and stdin/stdout.
-- Uses OpenAI's GPT-4o-mini model to process and summarize commit data.
+- Uses OpenAI's GPT-4o-mini model to process and summarise commit data.
 - No authentication required for public repositories.
 
 ## Prerequisites
@@ -31,14 +31,18 @@ This project demonstrates how to use the [LangChain4j](https://github.com/langch
    export OPENAI_API_KEY=your_openai_api_key
    ```
 3. **Clone this repository and build the project:** 
-git clone <this-repo-url> cd <this-repo> mvn clean package
+```
+git clone <this-repo-url> 
+cd <this-repo> 
+mvn clean package
+```
 
 4. ## Running the Example
 
 Run the `McpGithubToolsExample` class. This will:
 
 - Start the GitHub MCP server in a Docker container.
-- Use the LLM to summarize the last 3 commits of the [LangChain4j GitHub repository](https://github.com/langchain4j/langchain4j).
+- Use the LLM to summarise the last 3 commits of the [LangChain4j GitHub repository](https://github.com/langchain4j/langchain4j).
 
 You can run the example from your IDE or with Maven:
 `mvn exec:java -Dexec.mainClass=dev.langchain4j.example.mcp.github.McpGithubToolsExample`

--- a/mcp-github-example/src/main/java/dev/langchain4j/example/mcp/github/McpGithubToolsExample.java
+++ b/mcp-github-example/src/main/java/dev/langchain4j/example/mcp/github/McpGithubToolsExample.java
@@ -32,8 +32,7 @@ public class McpGithubToolsExample {
     public static void main(String[] args) throws Exception {
 
         ChatModel model = OpenAiChatModel.builder()
-                .apiKey("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")
-//                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .apiKey(System.getenv("OPENAI_API_KEY"))
                 .modelName("gpt-4o-mini")
                 .logRequests(true)
                 .logResponses(true)

--- a/mcp-github-example/src/main/java/dev/langchain4j/example/mcp/github/McpGithubToolsExample.java
+++ b/mcp-github-example/src/main/java/dev/langchain4j/example/mcp/github/McpGithubToolsExample.java
@@ -22,24 +22,25 @@ public class McpGithubToolsExample {
      * <p>
      * Running this example requires Docker to be installed on your machine,
      * because it spawns the GitHub MCP Server as a subprocess via Docker:
-     * `docker run -i mcp/github`.
+     * `docker run -i mcp/git`.
      * <p>
-     * You first need to build the Docker image of the GitHub MCP Server that is available at `mcp/github`.
-     * See https://github.com/modelcontextprotocol/servers/tree/main/src/github to build the image.
+     * You first need to build the Docker image of the GitHub MCP Server that is available at `mcp/git`.
+     * See https://github.com/modelcontextprotocol/servers/tree/main/src/git to build the image.
      * <p>
      * The communication with the GitHub MCP server is done directly via stdin/stdout.
      */
     public static void main(String[] args) throws Exception {
 
         ChatModel model = OpenAiChatModel.builder()
-                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .apiKey("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")
+//                .apiKey(System.getenv("OPENAI_API_KEY"))
                 .modelName("gpt-4o-mini")
                 .logRequests(true)
                 .logResponses(true)
                 .build();
 
         McpTransport transport = new StdioMcpTransport.Builder()
-                .command(List.of("/usr/local/bin/docker", "run", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "-i", "mcp/github"))
+                .command(List.of("/usr/local/bin/docker", "run", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "-i", "mcp/git"))
                 .logEvents(true)
                 .build();
 


### PR DESCRIPTION
- Added step-by-step instructions to build and run the mcp/git Docker image in Readme.md
- Fixed the mcp/git server URL in the example comment.