### PR TITLE
Improve API key loading in ApiKeys using external properties file in the JavaFX example

### DIFF
--- a/javafx-example/src/main/java/AnswerService.java
+++ b/javafx-example/src/main/java/AnswerService.java
@@ -20,7 +20,7 @@ public class AnswerService {
 
     private void initChat(SearchAction action) {
         StreamingChatModel model = OpenAiStreamingChatModel.builder()
-                .apiKey(ApiKeys.OPENAI_API_KEY)
+                .apiKey(ApiKeys.getOpenAiApiKey())
                 .modelName(GPT_4_O_MINI)
                 .build();
 

--- a/javafx-example/src/main/java/ApiKeys.java
+++ b/javafx-example/src/main/java/ApiKeys.java
@@ -1,6 +1,48 @@
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public class ApiKeys {
 
-    // You can use "demo" api key for demonstration purposes.
-    // You can get your own OpenAI API key here: https://platform.openai.com/account/api-keys
-    public static final String OPENAI_API_KEY = "demo";
+    private static final Logger LOGGER = LogManager.getLogger(ApiKeys.class);
+    private static final Properties properties = new Properties();
+
+    static {
+        try (InputStream input = ApiKeys.class.getClassLoader()
+                .getResourceAsStream("application.properties")) {
+
+            if (input == null) {
+                String message = "Could not find 'application.properties' in the classpath (resources folder).";
+                LOGGER.error(message);
+                throw new RuntimeException(message);
+            }
+
+            properties.load(input);
+            LOGGER.info("'application.properties' loaded successfully.");
+
+        } catch (IOException e) {
+            String message = "Failed to load 'application.properties' file.";
+            LOGGER.error(message, e);
+            throw new RuntimeException(message, e);
+        }
+    }
+
+    public static String get(String key) {
+        return properties.getProperty(key);
+    }
+
+    public static String getOpenAiApiKey() {
+        String apiKey = get("openai.api.key");
+
+        if (apiKey == null || apiKey.isBlank()) {
+            String message = "'openai.api.key' is missing or empty in 'application.properties'. Please define it to proceed.";
+            LOGGER.error(message);
+            throw new IllegalStateException(message);
+        }
+
+        return apiKey;
+    }
 }

--- a/javafx-example/src/main/resources/application.properties
+++ b/javafx-example/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+openai.api.key="YOUR_OPENAI_API_KEY"


### PR DESCRIPTION
### Summary

This pull request improves the existing `ApiKeys` class by:

- Loading the OpenAI API key from an external `application.properties` file located in `src/main/resources`.
- Providing clearer error messages when the properties file or API key is missing or invalid.

### Benefits

- Removes hardcoded API keys from the source code, enhancing security.
- Simplifies configuration and makes it environment-independent.
- Improves developer experience by making setup and testing easier.

If you prefer any adjustments or a different approach, I’m happy to update accordingly.
