### PR TITLE
feat: add RAG example to spring-boot-example module

### DIFF
--- a/spring-boot-example/src/main/java/dev/langchain4j/example/rag/RagAssistant.java
+++ b/spring-boot-example/src/main/java/dev/langchain4j/example/rag/RagAssistant.java
@@ -1,0 +1,8 @@
+package dev.langchain4j.example.rag;
+
+import dev.langchain4j.service.spring.AiService;
+
+@AiService
+public interface RagAssistant {
+    String answer(String question);
+}

--- a/spring-boot-example/src/main/java/dev/langchain4j/example/rag/RagConfiguration.java
+++ b/spring-boot-example/src/main/java/dev/langchain4j/example/rag/RagConfiguration.java
@@ -1,0 +1,42 @@
+package dev.langchain4j.example.rag;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.loader.ClassPathDocumentLoader;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingStoreIngestor;
+import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RagConfiguration {
+
+    @Bean
+    public EmbeddingModel embeddingModel() {
+        return OpenAiEmbeddingModel.withApiKey(System.getenv("OPENAI_API_KEY"));
+    }
+
+    @Bean
+    public EmbeddingStore<TextSegment> embeddingStore(EmbeddingModel embeddingModel) {
+        InMemoryEmbeddingStore<TextSegment> store = new InMemoryEmbeddingStore<>();
+        Document document = ClassPathDocumentLoader.loadDocument("rag-sample.txt");
+        EmbeddingStoreIngestor.ingest(document, store, embeddingModel);
+        return store;
+    }
+
+    @Bean
+    public ContentRetriever contentRetriever(
+            EmbeddingStore<TextSegment> embeddingStore,
+            EmbeddingModel embeddingModel) {
+        return EmbeddingStoreContentRetriever.builder()
+                .embeddingStore(embeddingStore)
+                .embeddingModel(embeddingModel)
+                .maxResults(3)
+                .build();
+    }
+}

--- a/spring-boot-example/src/main/java/dev/langchain4j/example/rag/RagController.java
+++ b/spring-boot-example/src/main/java/dev/langchain4j/example/rag/RagController.java
@@ -1,0 +1,19 @@
+package dev.langchain4j.example.rag;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/rag")
+public class RagController {
+
+    private final RagAssistant assistant;
+
+    public RagController(RagAssistant assistant) {
+        this.assistant = assistant;
+    }
+
+    @GetMapping("/ask")
+    public String ask(@RequestParam String question) {
+        return assistant.answer(question);
+    }
+}

--- a/spring-boot-example/src/main/resources/rag-sample.txt
+++ b/spring-boot-example/src/main/resources/rag-sample.txt
@@ -1,0 +1,5 @@
+LangChain4j is a Java library for building LLM-powered applications.
+It supports RAG (Retrieval-Augmented Generation) by combining embedding models,
+vector stores, and content retrievers. Spring Boot integration is available
+via the langchain4j-spring-boot-starter module, allowing developers to define
+AI services and RAG pipelines as standard Spring beans.


### PR DESCRIPTION
Closes #5072

Added RAG example to spring-boot-example module as requested.

Changes:
- RagConfiguration.java: beans for EmbeddingStore, EmbeddingModel and ContentRetriever
- RagAssistant.java: AI Service with RAG wired via ContentRetriever
- RagController.java: REST endpoint to interact with the assistant
- rag-sample.txt: sample document for ingestion