### PR TITLE
Add CockroachDB embedding store example

### DIFF
--- a/cockroachdb-example/pom.xml
+++ b/cockroachdb-example/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>cockroachdb-example</artifactId>
+    <version>1.16.0-beta26</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-cockroachdb</artifactId>
+            <version>1.16.0-beta26</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cockroachdb</artifactId>
+            <version>1.20.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+            <version>1.16.0-beta26</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.12</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/cockroachdb-example/src/main/java/CockroachDbEmbeddingStoreExample.java
+++ b/cockroachdb-example/src/main/java/CockroachDbEmbeddingStoreExample.java
@@ -1,0 +1,71 @@
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEmbeddingStore;
+import dev.langchain4j.community.store.embedding.cockroachdb.CockroachDbEngine;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.List;
+import org.testcontainers.containers.CockroachContainer;
+
+/**
+ * Minimal RAG example backed by CockroachDB.
+ *
+ * <p>Uses the Testcontainers cockroachdb/cockroach image and the default
+ * sequential-scan index so the example runs without any extra cluster setup.
+ * To switch to the C-SPANN distributed ANN index on CockroachDB v25.2 or
+ * later, enable the feature flag once per cluster:
+ *
+ * <pre>
+ *   SET CLUSTER SETTING feature.vector_index.enabled = true;
+ * </pre>
+ *
+ * <p>and pass {@code CSpannIndex.builder().build()} to the store via
+ * {@code .vectorIndex(...)}.
+ */
+public class CockroachDbEmbeddingStoreExample {
+
+    public static void main(String[] args) {
+        try (CockroachContainer cockroach = new CockroachContainer("cockroachdb/cockroach:latest-v25.2")) {
+            cockroach.start();
+
+            CockroachDbEngine engine = CockroachDbEngine.builder()
+                    .connectionString(cockroach.getJdbcUrl())
+                    .username(cockroach.getUsername())
+                    .password(cockroach.getPassword())
+                    .build();
+
+            EmbeddingModel embeddingModel = new AllMiniLmL6V2EmbeddingModel();
+
+            EmbeddingStore<TextSegment> embeddingStore = CockroachDbEmbeddingStore.builder()
+                    .engine(engine)
+                    .dimension(embeddingModel.dimension())
+                    .tableName("demo_embeddings")
+                    .build();
+
+            TextSegment segment1 = TextSegment.from("I like football.");
+            Embedding embedding1 = embeddingModel.embed(segment1).content();
+            embeddingStore.add(embedding1, segment1);
+
+            TextSegment segment2 = TextSegment.from("The weather is good today.");
+            Embedding embedding2 = embeddingModel.embed(segment2).content();
+            embeddingStore.add(embedding2, segment2);
+
+            Embedding queryEmbedding = embeddingModel.embed("What is your favourite sport?").content();
+            EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                    .queryEmbedding(queryEmbedding)
+                    .maxResults(1)
+                    .build();
+
+            List<EmbeddingMatch<TextSegment>> matches = embeddingStore.search(request).matches();
+            EmbeddingMatch<TextSegment> match = matches.get(0);
+
+            System.out.println(match.score()); // ~0.81
+            System.out.println(match.embedded().text()); // I like football.
+
+            engine.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `cockroachdb-example/` module mirroring `chroma-example/`. The
example boots a Testcontainers CockroachDB container, builds a
`CockroachDbEmbeddingStore`, indexes two short text segments, and runs a
similarity search.

It uses the default sequential-scan index so the example runs against any
CockroachDB v24.2+ without extra cluster setup. The class Javadoc shows
how to switch to the C-SPANN distributed ANN index on v25.2+.

## Companion PRs

- Integration module: langchain4j/langchain4j-community#673
- Docs page: langchain4j/langchain4j#5262

## Test plan

- [x] `mvn -pl cockroachdb-example -am package` succeeds
- [x] Running the example main method against the Testcontainers image prints the expected similarity score and matched text