### PR TITLE
Fix conflicting outputKey type in async conditional workflow example

### DIFF
--- a/agentic-tutorial/src/main/java/_5_conditional_workflow/_5b_Conditional_Workflow_Example_Async.java
+++ b/agentic-tutorial/src/main/java/_5_conditional_workflow/_5b_Conditional_Workflow_Example_Async.java
@@ -47,7 +47,7 @@ public class _5b_Conditional_Workflow_Example_Async {
                 .chatModel(CHAT_MODEL)
                 .async(true)
                 .tools(new OrganizingTools())
-                .outputKey("sentEmailId")
+                .outputKey("infoRequestResult")
                 .build();
 
         // 2. Build async conditional workflow
@@ -67,7 +67,8 @@ public class _5b_Conditional_Workflow_Example_Async {
                 }, infoRequester) // if needed, request more info from candidate
                 .output(agenticScope ->
                         (agenticScope.readState("managerReview", new CvReview(0, "no manager review needed"))).toString() +
-                                "\n" + agenticScope.readState("sentEmailId", 0)
+                                "\nRejection email ID: " + agenticScope.readState("sentEmailId", 0) +
+                                "\nInfo request result: " + agenticScope.readState("infoRequestResult", "none")
                 ) // final output is the manager review (if any)
                 .build();
 
@@ -92,7 +93,8 @@ public class _5b_Conditional_Workflow_Example_Async {
 
 
         // 4. Run the conditional async workflow
-        candidateResponder.invoke(arguments);
+        String invoke = (String) candidateResponder.invoke(arguments);
+        System.out.println(invoke);
 
         System.out.println("=== Finished execution of async conditional workflow ===");
     }

--- a/agentic-tutorial/src/main/java/_7_supervisor_orchestration/_7b_Supervisor_Orchestration_Advanced.java
+++ b/agentic-tutorial/src/main/java/_7_supervisor_orchestration/_7b_Supervisor_Orchestration_Advanced.java
@@ -54,12 +54,10 @@ public class _7b_Supervisor_Orchestration_Advanced {
         InterviewOrganizer interviewOrganizer = AgenticServices.agentBuilder(InterviewOrganizer.class)
                 .chatModel(CHAT_MODEL)
                 .tools(new OrganizingTools())
-                .outputKey("response")
                 .build();
         EmailAssistant emailAssistant = AgenticServices.agentBuilder(EmailAssistant.class)
                 .chatModel(CHAT_MODEL)
                 .tools(new OrganizingTools())
-                .outputKey("response")
                 .build();
 
         // 2. Build supervisor


### PR DESCRIPTION
https://github.com/langchain4j/langchain4j-examples/blob/8287059914ad11de158753513c5c27fdefc4cae6/agentic-tutorial/src/main/java/_5_conditional_workflow/_5b_Conditional_Workflow_Example_Async.java#L35-L51

Running _5b_Conditional_Workflow_Example_Async throws:
AgenticSystemConfigurationException: Conflicting types for key 'sentEmailId': int and java.lang.String

## Root Cause
EmailAssistant (returns int) and InfoRequester (returns String) both used outputKey("sentEmailId"). The framework detects conflicting types for the same key at build time and fails.

## else

The same issue exists with  `_7b_Supervisor_Orchestration_Advanced`