### PR TITLE
fix: add missing chatMemoryProvider for @MemoryId usage

### DIFF
--- a/other-examples/src/main/java/OtherServiceExamples.java
+++ b/other-examples/src/main/java/OtherServiceExamples.java
@@ -2,6 +2,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.input.structured.StructuredPrompt;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.output.structured.Description;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.service.*;
 
 import java.math.BigDecimal;
@@ -380,6 +381,7 @@ public class OtherServiceExamples {
 
             Assistant assistant = AiServices.builder(Assistant.class)
                     .chatModel(chatModel)
+                    .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(10))
                     .systemMessageProvider(systemMessageProvider)
                     .build();
 

--- a/rag-examples/src/main/java/_3_advanced/_05_Advanced_RAG_with_Metadata_Filtering_Examples.java
+++ b/rag-examples/src/main/java/_3_advanced/_05_Advanced_RAG_with_Metadata_Filtering_Examples.java
@@ -6,6 +6,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.onnx.bgesmallenv15q.BgeSmallEnV15QuantizedEmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
 import dev.langchain4j.rag.query.Query;
@@ -106,6 +107,7 @@ class _05_Advanced_RAG_with_Metadata_Filtering_Examples {
         PersonalizedAssistant personalizedAssistant = AiServices.builder(PersonalizedAssistant.class)
                 .chatModel(chatModel)
                 .contentRetriever(contentRetriever)
+                .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(10))
                 .build();
 
         // when


### PR DESCRIPTION
## Problem

Examples using `@MemoryId` in their AI Service interface throw a runtime exception:
In order to use @MemoryId, please configure the ChatMemoryProvider on the 'xxx'