### PR TITLE
Fix incorrect readState key in human-in-the-loop examples

### DIFF
--- a/agentic-tutorial/src/main/java/_9_human_in_the_loop/_9a_HumanInTheLoop_Simple_Validator.java
+++ b/agentic-tutorial/src/main/java/_9_human_in_the_loop/_9a_HumanInTheLoop_Simple_Validator.java
@@ -35,7 +35,7 @@ public class _9a_HumanInTheLoop_Simple_Validator {
                 .description("validates the model's proposed hiring decision")
                 .outputKey("finalDecision") // checked by human
                 .responseProvider(scope -> {
-                    System.out.println("AI hiring assistant suggests: " + scope.readState("request"));
+                    System.out.println("AI hiring assistant suggests: " + scope.readState("modelDecision"));
                     System.out.println("Please confirm the final decision.");
                     System.out.println("Options: Invite on-site (I), Reject (R), Hold (H)");
                     System.out.print("> "); // we need input validation and error handling in real-life systems

--- a/agentic-tutorial/src/main/java/_9_human_in_the_loop/_9b_HumanInTheLoop_Chatbot_With_Memory.java
+++ b/agentic-tutorial/src/main/java/_9_human_in_the_loop/_9b_HumanInTheLoop_Chatbot_With_Memory.java
@@ -51,7 +51,7 @@ public class _9b_HumanInTheLoop_Chatbot_With_Memory {
                 .description("agent that asks input from the user")
                 .outputKey("candidateAnswer") // matches one of the proposer's input variable names
                 .responseProvider(scope -> {
-                    System.out.println(scope.readState("request"));
+                    System.out.println(scope.readState("proposal"));
                     System.out.print("> ");
                     try {
                         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));


### PR DESCRIPTION
## Problem

In the two human-in-the-loop examples (`_9a` and `_9b`), the `responseProvider`
reads state from `"request"`, which does not match the `outputKey` of the
preceding agent. This causes the human validator/responder to see `null`
instead of the actual model output.