### PR TITLE
Add Hazelcast example (chat memory + CP map + embedding store)

### DIFF
--- a/hazelcast-example/pom.xml
+++ b/hazelcast-example/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>hazelcast-example</artifactId>
+    <version>1.17.0-beta27</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <langchain4j.version>1.17.0-beta27</langchain4j.version>
+    </properties>
+
+    <repositories>
+        <!-- Required for com.hazelcast:hazelcast-enterprise (not on Maven Central) -->
+        <repository>
+            <id>hazelcast-release</id>
+            <name>Hazelcast Release Repository</name>
+            <url>https://repository.hazelcast.com/release/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+
+        <!--
+            The Enterprise module re-exports langchain4j-community-hazelcast, so this single
+            dependency provides HazelcastChatMemoryStore (IMap), HazelcastCPMapChatMemoryStore (CPMap)
+            and HazelcastEmbeddingStore (VectorCollection), and brings Hazelcast Enterprise
+            transitively. A valid Hazelcast Enterprise license (HZ_LICENSEKEY) is required at runtime.
+        -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-hazelcast-enterprise</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>
+            <version>${langchain4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.7</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/hazelcast-example/src/main/java/HazelcastCPMapChatMemoryStoreExample.java
+++ b/hazelcast-example/src/main/java/HazelcastCPMapChatMemoryStoreExample.java
@@ -1,0 +1,63 @@
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import dev.langchain4j.community.store.memory.chat.hazelcast.HazelcastCPMapChatMemoryStore;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Stores chat memory in a strongly-consistent Hazelcast {@code CPMap} (CP Subsystem / Raft).
+ * <p>
+ * Requires Hazelcast Enterprise (a valid {@code HZ_LICENSEKEY}) and the CP Subsystem enabled.
+ * A {@code CPMap} needs a CP quorum of at least 3 members, so this example boots a three-member
+ * embedded cluster in-process. The members discover each other via Hazelcast's default multicast,
+ * and the code waits for the CP Subsystem to finish discovery before using the store.
+ */
+public class HazelcastCPMapChatMemoryStoreExample {
+
+    private static final int CP_MEMBER_COUNT = 3;
+
+    public static void main(String[] args) throws Exception {
+        Config config = new Config();
+        config.setLicenseKey(System.getenv("HZ_LICENSEKEY"));
+        config.getCPSubsystemConfig().setCPMemberCount(CP_MEMBER_COUNT);
+
+        // All three members share the same config; Hazelcast allows reusing one Config instance.
+        List<HazelcastInstance> members = new ArrayList<>();
+        for (int i = 0; i < CP_MEMBER_COUNT; i++) {
+            members.add(Hazelcast.newHazelcastInstance(config));
+        }
+
+        HazelcastInstance hz = members.get(0);
+        // Block until the CP Subsystem has formed its quorum before using the CPMap.
+        hz.getCPSubsystem()
+                .getCPSubsystemManagementService()
+                .awaitUntilDiscoveryCompleted(60, TimeUnit.SECONDS);
+
+        try {
+            ChatMemoryStore store = HazelcastCPMapChatMemoryStore.builder()
+                    .hazelcastInstance(hz)
+                    .name("chatMemory")
+                    .build();
+
+            String memoryId = "user-1";
+            store.updateMessages(
+                    memoryId,
+                    List.of(
+                            UserMessage.from("Hello, my name is Andrii."),
+                            AiMessage.from("Hi Andrii, how can I help you today?")));
+
+            List<ChatMessage> messages = store.getMessages(memoryId);
+            messages.forEach(System.out::println);
+        } finally {
+            // Terminate (rather than gracefully shut down) to avoid CP membership-change
+            // races when all members leave at once.
+            members.forEach(member -> member.getLifecycleService().terminate());
+        }
+    }
+}

--- a/hazelcast-example/src/main/java/HazelcastChatMemoryStoreExample.java
+++ b/hazelcast-example/src/main/java/HazelcastChatMemoryStoreExample.java
@@ -1,0 +1,39 @@
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import dev.langchain4j.community.store.memory.chat.hazelcast.HazelcastChatMemoryStore;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.List;
+
+/**
+ * Stores chat memory in a Hazelcast {@code IMap} using the open-source
+ * {@code langchain4j-community-hazelcast} module. Runs against the open-source
+ * Community Edition with no license.
+ */
+public class HazelcastChatMemoryStoreExample {
+
+    public static void main(String[] args) {
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance(new Config());
+        try {
+            ChatMemoryStore store = HazelcastChatMemoryStore.builder()
+                    .hazelcastInstance(hz)
+                    .name("chatMemory") // optional, defaults to "chatMemory"
+                    .build();
+
+            String memoryId = "user-1";
+            store.updateMessages(
+                    memoryId,
+                    List.of(
+                            UserMessage.from("Hello, my name is Andrii."),
+                            AiMessage.from("Hi Andrii, how can I help you today?")));
+
+            List<ChatMessage> messages = store.getMessages(memoryId);
+            messages.forEach(System.out::println);
+        } finally {
+            hz.shutdown();
+        }
+    }
+}

--- a/hazelcast-example/src/main/java/HazelcastEmbeddingStoreExample.java
+++ b/hazelcast-example/src/main/java/HazelcastEmbeddingStoreExample.java
@@ -1,0 +1,60 @@
+import com.hazelcast.config.Config;
+import com.hazelcast.config.vector.Metric;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import dev.langchain4j.community.store.embedding.hazelcast.HazelcastEmbeddingStore;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.List;
+
+/**
+ * Stores embeddings in a Hazelcast {@code VectorCollection} and runs a similarity search.
+ * <p>
+ * Requires Hazelcast Enterprise (a valid {@code HZ_LICENSEKEY}). An embedded single-member
+ * cluster is used here; no external process is needed.
+ */
+public class HazelcastEmbeddingStoreExample {
+
+    public static void main(String[] args) {
+        Config config = new Config();
+        config.setLicenseKey(System.getenv("HZ_LICENSEKEY"));
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
+        try {
+            EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+            EmbeddingStore<TextSegment> store = HazelcastEmbeddingStore.builder()
+                    .hazelcastInstance(hz)
+                    .collectionName("embeddings") // optional, defaults to "embeddings"
+                    .dimension(384) // must match the embedding model
+                    .metric(Metric.COSINE) // optional, defaults to COSINE
+                    .build();
+
+            TextSegment segment1 = TextSegment.from("I like football.");
+            Embedding embedding1 = embeddingModel.embed(segment1).content();
+            store.add(embedding1, segment1);
+
+            TextSegment segment2 = TextSegment.from("The weather is good today.");
+            Embedding embedding2 = embeddingModel.embed(segment2).content();
+            store.add(embedding2, segment2);
+
+            Embedding queryEmbedding =
+                    embeddingModel.embed("What is your favourite sport?").content();
+            EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                    .queryEmbedding(queryEmbedding)
+                    .maxResults(1)
+                    .build();
+
+            EmbeddingSearchResult<TextSegment> result = store.search(request);
+            List<EmbeddingMatch<TextSegment>> matches = result.matches();
+            matches.forEach(match -> System.out.println(match.score() + " : " + match.embedded().text()));
+        } finally {
+            hz.shutdown();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>google-ai-gemini-examples</module>
         <module>google-alloydb-example</module>
         <module>gpullama3.java-example</module>
+        <module>hazelcast-example</module>
         <module>helidon-examples</module>
         <module>hibernate-example</module>
         <module>infinispan-example</module>


### PR DESCRIPTION
Adds a `hazelcast-example` module with three runnable examples for the `langchain4j-community-hazelcast(-enterprise)` `1.17.0-beta27` integration, and registers the module in the aggregator pom.

## Examples
- **`HazelcastChatMemoryStoreExample`** — `ChatMemoryStore` backed by a Hazelcast `IMap`.
- **`HazelcastCPMapChatMemoryStoreExample`** — strongly-consistent (linearizable, Raft) `ChatMemoryStore` backed by a `CPMap`. Boots an embedded 3-member cluster in-process, since the CP Subsystem requires a quorum of at least 3 members.
- **`HazelcastEmbeddingStoreExample`** — `EmbeddingStore` backed by a Hazelcast `VectorCollection`, with a similarity search.

## Notes
- The Enterprise examples (`CPMap`, `EmbeddingStore`) require **Hazelcast Enterprise**: a valid license via the `HZ_LICENSEKEY` env var, plus the Hazelcast release repository (already configured in the module pom; the Enterprise jars are not on Maven Central).
- All three examples were run end-to-end against `1.17.0-beta27` and exit cleanly.
- The module is linked from the Hazelcast integration docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)