### PR TITLE
Fix inconsist return type of  same key in Conditional_Workflow_Example_Async

### DIFF
--- a/agentic-tutorial/src/main/java/_5_conditional_workflow/InfoRequester.java
+++ b/agentic-tutorial/src/main/java/_5_conditional_workflow/InfoRequester.java
@@ -8,10 +8,11 @@ import domain.CvReview;
 
 public interface InfoRequester {
 
-    @Agent("Emails a candidate to obtain extra info")
+    @Agent("Emails a candidate to obtain extra info, returns the sent email ID or 0 if no email could be sent")
     @SystemMessage("""
             You send a kind email to candidates to request extra information the company needs
             in order to review the application. Make clear that their application is still being considered.
+            You return the sent email ID.
             """)
     @UserMessage("""
             HR review with description of missing info: {{cvReview}}
@@ -20,5 +21,5 @@ public interface InfoRequester {
             
             Job description: {{jobDescription}}
             """)
-    String send(@V("candidateContact") String candidateContact, @V("jobDescription") String jobDescription, @V("cvReview") CvReview hrReview);
+    int send(@V("candidateContact") String candidateContact, @V("jobDescription") String jobDescription, @V("cvReview") CvReview hrReview);
 }


### PR DESCRIPTION
Fixes a build-time agentic workflow configuration error in the async conditional workflow example.

`EmailAssistant` and `InfoRequester` both wrote to `sentEmailId`, but their method return types differed (`int` vs `String`). LangChain4j validates AgenticScope key types during workflow construction and rejects conflicting types.

This changes `InfoRequester` to return the sent email ID as an `int`, matching `EmailAssistant` and the shared `sentEmailId` key.

Validation:
- `./mvnw -pl agentic-tutorial -DskipTests compile`